### PR TITLE
Link to api title from toc

### DIFF
--- a/lib/prmd/templates/table_of_contents.erb
+++ b/lib/prmd/templates/table_of_contents.erb
@@ -6,6 +6,6 @@
   <% _, schemata = schema.dereference(property) %>
 - <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
   <% schemata.fetch('links', []).each do |l| %>
-  - <a href="#link-<%= l['method'] %>-<%= resource %>-<%= l['href'] %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
+  - <a href="#<%= schemata['title'].gsub(/\s/, '-').downcase %>-<%= l['title'].gsub(/\s/, '-').downcase %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
   <% end %>
 <% end %>

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -39,7 +39,7 @@ class InteragentRenderTest < Minitest::Test
 
     assert_match /^## The table of contents/, markdown
     assert_match '<a href="#resource-app"', markdown
-    assert_match '- <a href="#link-POST-app-/apps">POST /apps', markdown
+    assert_match '- <a href="#app-create-app">POST /apps', markdown
     assert_match '<a name="link-POST-app-/apps"', markdown
   end
 


### PR DESCRIPTION
### Description

TOC link is very usefull, but link with `{hoge}` parameter is not valid.
So I changed link target from link url to title of api description part.

### Sample

please click each toc link on these .md files.

**before**
https://github.com/ginkouno/md_link_sample/blob/master/schema_toc_link_before.md

**after**
https://github.com/ginkouno/md_link_sample/blob/master/schema_toc_link_after.md