### PR TITLE
Use detail tag to omit long document

### DIFF
--- a/lib/prmd/templates/schemata.md.erb
+++ b/lib/prmd/templates/schemata.md.erb
@@ -21,6 +21,8 @@ Stability: `<%= schemata['stability'] %>`
 <%- if schemata['properties'] && !schemata['properties'].empty? %>
 ### Attributes
 
+<details>
+
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 <%- refs = extract_schemata_refs(schema, schemata['properties']).map {|v| v && v.split("/")} %>
@@ -46,3 +48,5 @@ Stability: `<%= schemata['stability'] %>`
   })
 %>
 <%- end -%>
+
+</details>

--- a/lib/prmd/templates/schemata/link.md.erb
+++ b/lib/prmd/templates/schemata/link.md.erb
@@ -5,6 +5,8 @@
 -%>
 ### <a name="link-<%= link['method'] %>-<%= resource %>-<%= link['href'] %>"><%= title %> <%= link['title'] %></a>
 
+<details>
+
 <%= link['description'] %>
 
 ```
@@ -78,3 +80,5 @@ HTTP/1.1 <%=
 <%- end %>
 ```
 <%- end %>
+
+</details>


### PR DESCRIPTION
### Description

Docが長い時に表示が長く辛くなるので、途中を折りたためるように、```<detail></detail>``` で囲むようにしました。

### Markdown doc sample

https://github.com/ginkouno/md_link_sample/blob/master/schema_with_detail_tag.md